### PR TITLE
Updates: boost fix & mean settings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,8 +108,13 @@ ROOTGLIBS    := $(shell root-config --glibs)
 CMSSWFLAGS    = -I$(CMSSW_BASE)/src -I$(CMSSW_RELEASE_BASE)/src
 CMSSWLIBS     = -L${CMSSW_BASE}/lib/${SCRAM_ARCH} -L${CMSSW_RELEASE_BASE}/lib/${SCRAM_ARCH} -lCondFormatsEgammaObjects
 
-#CXXFLAGS     += $(ROOTCFLAGS) -I$(INCLUDE_DIR) $(CMSSWFLAGS)  -fno-exceptions -I$(CMSSW_DATA_PATH)/../external/boost/1.47.0-cms/
-CXXFLAGS     += $(ROOTCFLAGS) -I$(INCLUDE_DIR) $(CMSSWFLAGS)  -fexceptions  -I$(CMSSW_DATA_PATH)/../external/boost/1.63.0-omkpbe4/include -I/cvmfs/cms.cern.ch/slc6_amd64_gcc700/cms/vdt/0.4.0/include/
+#we dont know exactly where the boost directory is for CMSSW, we just pick the 
+#the first one in the directory, dont think this will matter
+BOOST_DIR     = $(shell ls $$CMSSW_DATA_PATH/../external/boost/* -d  | head -n 1)
+
+CXXFLAGS     += $(ROOTCFLAGS) -I$(INCLUDE_DIR) $(CMSSWFLAGS)  -fexceptions  -I$(BOOST_DIR)/include -I/cvmfs/cms.cern.ch/slc6_amd64_gcc700/cms/vdt/0.4.0/include/
+
+
 
 LIBS          = $(ROOTLIBS) $(SYSLIBS) $(USERLIBS) $(CMSSWLIBS)
 GLIBS         = $(ROOTGLIBS) $(SYSLIBS)

--- a/main/RegressionApplier.cc
+++ b/main/RegressionApplier.cc
@@ -159,6 +159,7 @@ int main(int argc, char** argv)
       fullSigmaBranch->Fill();
       fullInvTarBranch->Fill();
     }
+    outTree->Write(0,TObject::kOverwrite);
     outFile->Write();
   }
 

--- a/packages/RegresTrainer/include/HybridGBRMaker.h
+++ b/packages/RegresTrainer/include/HybridGBRMaker.h
@@ -48,7 +48,10 @@ class HybridGBRMaker
                   const std::string& treeName,
                   const std::string& outputDirectory,
                   bool doCombine,
-                  bool doEB
+                  bool doEB,
+		  float meanMin,
+		  float meanMax, 
+                  bool fixedMean
                   );
         void addVariableEB(const std::string& name);
         void addVariableEE(const std::string& name);
@@ -86,6 +89,10 @@ class HybridGBRMaker
         std::vector<std::string> m_variablesEE;
         std::vector<std::string> m_variablesComb;
         int m_ntrees;
+
+        float m_meanMin;
+        float m_meanMax;
+        bool m_fixedMean;
 
 };
 

--- a/packages/RegresTrainer/include/ParReader.h
+++ b/packages/RegresTrainer/include/ParReader.h
@@ -47,7 +47,9 @@ struct RegressionParameters
     bool        doCombine;
 
     bool        doEB;
-
+    float       meanMin;
+    float       meanMax;
+    bool        fixMean;
 };
 
 

--- a/packages/RegresTrainer/src/ParReader.cc
+++ b/packages/RegresTrainer/src/ParReader.cc
@@ -90,7 +90,9 @@ bool ParReader::read(const string& parFileName)
        stringstream keyDoCombine;
 
        stringstream keyDoEB;
-
+       stringstream meanMin;
+       stringstream meanMax;
+       stringstream fixMean;
 
        keyInputFiles           <<  baseName  <<  "."  <<  i  <<  ".InputFiles";
        keyTree                 <<  baseName  <<  "."  <<  i  <<  ".Tree";
@@ -113,6 +115,9 @@ bool ParReader::read(const string& parFileName)
        keyDoCombine            <<  baseName  <<  "."  <<  i  <<  ".DoCombine";
 
        keyDoEB                 <<  baseName  <<  "."  <<  i  <<  ".DoEB";
+       meanMin                 <<  baseName  <<  "."  <<  i  <<  ".MeanMin";
+       meanMax                 <<  baseName  <<  "."  <<  i  <<  ".MeanMax";
+       fixMean                 <<  baseName  <<  "."  <<  i  <<  ".FixMean";
 
 
        RegressionParameters par;
@@ -137,7 +142,11 @@ bool ParReader::read(const string& parFileName)
        par.doCombine           =        params.GetValue(keyDoCombine.str().c_str(),          false);
 
        par.doEB                =        params.GetValue(keyDoEB.str().c_str(),               true);
-
+       
+       par.meanMin             =        params.GetValue(meanMin.str().c_str(),               0.2);
+       par.meanMax             =        params.GetValue(meanMax.str().c_str(),               2.0);
+       par.fixMean             =        params.GetValue(fixMean.str().c_str(),               false);
+       
        m_regParams.push_back(par);
 
     }

--- a/packages/RegresTrainer/src/RegressionManager.cc
+++ b/packages/RegresTrainer/src/RegressionManager.cc
@@ -169,7 +169,10 @@ bool RegressionManager::makeRegression()
                     it->treeName,
                     m_reader.outputDirectory(),
                     it->doCombine,
-                    it->doEB
+		    it->doEB,
+		    it->meanMin,
+		    it->meanMax,
+		    it->fixMean
                     );
             if(!status)
                 break;


### PR DESCRIPTION
This updates the regression package with two bug fixes and two new features

1) now tries to auto deduce boost location which should fix errors users were getting
2) a vane attempt to try and fix the crash when copying a tree
3) allows the mean range to be specified in the config file
4) allows the mean to be fixed at 1 and not regressed. This is useful for retraining the resolution on the sample with the real intercalibration constants 